### PR TITLE
Add BookWise logo assets and update layout

### DIFF
--- a/BookWise.Web/Pages/Shared/_Layout.cshtml
+++ b/BookWise.Web/Pages/Shared/_Layout.cshtml
@@ -23,31 +23,11 @@
         <header class="top-nav">
             <div class="nav-left">
                 <a class="brand" asp-area="" asp-page="/Index">
+                    <span class="sr-only">BookWise</span>
                     <span class="brand-icon" aria-hidden="true">
-                        <svg width="28" height="28" viewBox="0 0 100 100" fill="none" xmlns="http://www.w3.org/2000/svg">
-                            <!-- Person's head -->
-                            <circle cx="50" cy="25" r="12" fill="#3498db" stroke="#3498db" stroke-width="1"/>
-                            
-                            <!-- Person's body (simplified) -->
-                            <ellipse cx="50" cy="50" rx="8" ry="15" fill="#3498db"/>
-                            
-                            <!-- Open book pages -->
-                            <path d="M20 45 Q50 35 80 45 L80 85 Q50 75 20 85 Z" fill="#3498db" stroke="#3498db" stroke-width="1"/>
-                            
-                            <!-- Book center fold -->
-                            <line x1="50" y1="40" x2="50" y2="80" stroke="white" stroke-width="2"/>
-                            
-                            <!-- Book pages lines -->
-                            <line x1="30" y1="50" x2="45" y2="50" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
-                            <line x1="30" y1="56" x2="45" y2="56" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
-                            <line x1="30" y1="62" x2="45" y2="62" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
-                            
-                            <line x1="55" y1="50" x2="70" y2="50" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
-                            <line x1="55" y1="56" x2="70" y2="56" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
-                            <line x1="55" y1="62" x2="70" y2="62" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
-                        </svg>
+                        <img src="~/img/bookwise-icon.svg" width="36" height="36" alt="" />
                     </span>
-                    <span class="brand-name">BookWise</span>
+                    <span class="brand-name" aria-hidden="true">BookWise</span>
                 </a>
                 <nav class="nav-links" aria-label="Primary">
                     <a class="nav-link" asp-page="/Index">My Books</a>

--- a/BookWise.Web/wwwroot/img/bookwise-icon.svg
+++ b/BookWise.Web/wwwroot/img/bookwise-icon.svg
@@ -1,12 +1,13 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" role="img" aria-labelledby="title">
+  <title id="title">BookWise icon</title>
   <defs>
-    <linearGradient id="faviconGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+    <linearGradient id="iconGradient" x1="0%" y1="0%" x2="100%" y2="100%">
       <stop offset="0%" stop-color="#2D7FF9" />
       <stop offset="100%" stop-color="#52C7EA" />
     </linearGradient>
   </defs>
   <g fill="none" fill-rule="evenodd">
-    <path d="M64 16c19.882 0 36 16.118 36 36v32c0 4.418-3.582 8-8 8-1.906 0-3.747-.671-5.197-1.878-4.316-3.546-9.576-5.538-15.067-5.538-7.256 0-13.965 3.136-18.71 8.606-3.01 3.457-8.323 3.73-11.78.72A8 8 0 0 1 36 88V52c0-19.882 16.118-36 36-36Z" fill="url(#faviconGradient)" />
+    <path d="M64 16c19.882 0 36 16.118 36 36v32c0 4.418-3.582 8-8 8-1.906 0-3.747-.671-5.197-1.878-4.316-3.546-9.576-5.538-15.067-5.538-7.256 0-13.965 3.136-18.71 8.606-3.01 3.457-8.323 3.73-11.78.72A8 8 0 0 1 36 88V52c0-19.882 16.118-36 36-36Z" fill="url(#iconGradient)" />
     <path d="M94 88c0 4.418-3.358 8-7.5 8S79 92.418 79 88s3.358-8 7.5-8 7.5 3.582 7.5 8Z" fill="#fff" opacity=".9" />
     <path d="M58 88c0 4.418-3.358 8-7.5 8S43 92.418 43 88s3.358-8 7.5-8 7.5 3.582 7.5 8Z" fill="#fff" opacity=".9" />
     <circle cx="50.5" cy="88" r="3.5" fill="#23395B" />

--- a/BookWise.Web/wwwroot/img/bookwise-logo.svg
+++ b/BookWise.Web/wwwroot/img/bookwise-logo.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 360 120" role="img" aria-labelledby="title desc">
+  <title id="title">BookWise logo</title>
+  <desc id="desc">An open book forming an owl face next to the BookWise wordmark.</desc>
+  <defs>
+    <linearGradient id="bookwiseGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2D7FF9" />
+      <stop offset="100%" stop-color="#52C7EA" />
+    </linearGradient>
+  </defs>
+  <g fill="none" fill-rule="evenodd">
+    <g transform="translate(12 18)">
+      <path d="M61 12c23.196 0 42 18.804 42 42v36c0 4.418-3.582 8-8 8-2.01 0-3.955-.742-5.44-2.08-4.586-4.084-10.498-6.356-16.727-6.356-8.03 0-15.457 3.56-20.805 9.56-3.076 3.458-8.343 3.78-11.8.703A8 8 0 0 1 36 92V54C36 30.804 54.804 12 78 12Z" fill="url(#bookwiseGradient)" />
+      <path d="M95 87.5c0 4.142-3.358 7.5-7.5 7.5-4.142 0-7.5-3.358-7.5-7.5S83.358 80 87.5 80s7.5 3.358 7.5 7.5Z" fill="#fff" opacity=".9" />
+      <path d="M59 87.5c0 4.142-3.358 7.5-7.5 7.5S44 91.642 44 87.5 47.358 80 51.5 80s7.5 3.358 7.5 7.5Z" fill="#fff" opacity=".9" />
+      <circle cx="51.5" cy="87.5" r="3.5" fill="#23395B" />
+      <circle cx="87.5" cy="87.5" r="3.5" fill="#23395B" />
+      <path d="M36.2 52.5 11 63.7c-4.018 1.782-8.768-.045-10.55-4.063C-.332 56.62 1.496 51.87 5.513 50.088l32.447-14.398a8.01 8.01 0 0 1 6.494.246l15.646 7.3c11.126 5.192 24.203 5.154 35.297-.102l15.184-7.194c3.97-1.882 8.71-.11 10.592 3.86 1.882 3.97.11 8.711-3.86 10.593l-23.984 11.359c-13.797 6.542-29.736 6.588-43.57.127l-13.66-6.3c-1.982-.914-4.267-.942-6.3-.086Z" fill="#1B4F9C" />
+    </g>
+    <g fill="#23395B" font-family="'Inter', 'Segoe UI', sans-serif" font-size="64" font-weight="600" letter-spacing=".5">
+      <text x="150" y="78">Book</text>
+      <text x="150" y="118">Wise</text>
+    </g>
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- add a reusable BookWise wordmark and icon SVG assets to the web root
- update the site layout header to reference the new icon while keeping accessible text
- refresh the favicon to match the updated brand mark

## Testing
- not run (dotnet SDK is unavailable in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68dfd66eec04832c935e11d07a960cdc