### PR TITLE
Render bookshelf sections from stored data

### DIFF
--- a/BookWise.Web/Pages/Index.cshtml
+++ b/BookWise.Web/Pages/Index.cshtml
@@ -24,38 +24,22 @@
             <h2 class="section-title">In Reading</h2>
             <button class="view-all-btn" type="button">View all</button>
         </div>
-        <div class="books-grid">
-            <a class="book-item" asp-page="/BookDetails">
-                <div class="book-cover">
-                    <img src="https://images.unsplash.com/photo-1544947950-fa07a98d237f?w=300&h=450&fit=crop&crop=center" alt="The Silent Observer" />
-                </div>
-                <h3 class="book-title">The Silent Observer</h3>
-            </a>
-            <a class="book-item" asp-page="/BookDetails">
-                <div class="book-cover">
-                    <img src="https://images.unsplash.com/photo-1518373714866-3f1478910cc0?w=300&h=450&fit=crop&crop=center" alt="Echoes of the Past" />
-                </div>
-                <h3 class="book-title">Echoes of the Past</h3>
-            </a>
-            <a class="book-item" asp-page="/BookDetails">
-                <div class="book-cover">
-                    <img src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=300&h=450&fit=crop&crop=center" alt="The Last Frontier" />
-                </div>
-                <h3 class="book-title">The Last Frontier</h3>
-            </a>
-            <a class="book-item" asp-page="/BookDetails">
-                <div class="book-cover">
-                    <img src="https://images.unsplash.com/photo-1441974231531-c6227db76b6e?w=300&h=450&fit=crop&crop=center" alt="Whispers of the Wind" />
-                </div>
-                <h3 class="book-title">Whispers of the Wind</h3>
-            </a>
-            <a class="book-item" asp-page="/BookDetails">
-                <div class="book-cover">
-                    <img src="https://images.unsplash.com/photo-1439066615861-d1af74d74000?w=300&h=450&fit=crop&crop=center" alt="Secrets of the Sea" />
-                </div>
-                <h3 class="book-title">Secrets of the Sea</h3>
-            </a>
-        </div>
+        @if (Model.CurrentlyReading.Any())
+        {
+            <div class="books-grid">
+                @foreach (var book in Model.CurrentlyReading)
+                {
+                    <partial name="Shared/_BookShelfItem" model="book" />
+                }
+            </div>
+        }
+        else
+        {
+            <div class="section-empty-message">
+                <h3>No books in progress yet</h3>
+                <p>When you start reading a book it will appear here for quick access.</p>
+            </div>
+        }
     </section>
 
     <!-- Already Read Section -->
@@ -64,38 +48,22 @@
             <h2 class="section-title">Already Read</h2>
             <button class="view-all-btn" type="button">View all</button>
         </div>
-        <div class="books-grid">
-            <a class="book-item" asp-page="/BookDetails">
-                <div class="book-cover">
-                    <img src="https://images.unsplash.com/photo-1518373714866-3f1478910cc0?w=300&h=450&fit=crop&crop=center" alt="The Hidden Path" />
-                </div>
-                <h3 class="book-title">The Hidden Path</h3>
-            </a>
-            <a class="book-item" asp-page="/BookDetails">
-                <div class="book-cover">
-                    <img src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=300&h=450&fit=crop&crop=center" alt="Beyond the Horizon" />
-                </div>
-                <h3 class="book-title">Beyond the Horizon</h3>
-            </a>
-            <a class="book-item" asp-page="/BookDetails">
-                <div class="book-cover">
-                    <img src="https://images.unsplash.com/photo-1544947950-fa07a98d237f?w=300&h=450&fit=crop&crop=center" alt="The Forgotten City" />
-                </div>
-                <h3 class="book-title">The Forgotten City</h3>
-            </a>
-            <a class="book-item" asp-page="/BookDetails">
-                <div class="book-cover">
-                    <img src="https://images.unsplash.com/photo-1441974231531-c6227db76b6e?w=300&h=450&fit=crop&crop=center" alt="Shadows of the Empire" />
-                </div>
-                <h3 class="book-title">Shadows of the Empire</h3>
-            </a>
-            <a class="book-item" asp-page="/BookDetails">
-                <div class="book-cover">
-                    <img src="https://images.unsplash.com/photo-1439066615861-d1af74d74000?w=300&h=450&fit=crop&crop=center" alt="The Lost Artifact" />
-                </div>
-                <h3 class="book-title">The Lost Artifact</h3>
-            </a>
-        </div>
+        @if (Model.AlreadyRead.Any())
+        {
+            <div class="books-grid">
+                @foreach (var book in Model.AlreadyRead)
+                {
+                    <partial name="Shared/_BookShelfItem" model="book" />
+                }
+            </div>
+        }
+        else
+        {
+            <div class="section-empty-message">
+                <h3>No finished books yet</h3>
+                <p>Mark a book as completed to celebrate it in this shelf.</p>
+            </div>
+        }
     </section>
 
     <!-- Plan to Read Section -->
@@ -104,37 +72,21 @@
             <h2 class="section-title">Plan to Read</h2>
             <button class="view-all-btn" type="button">View all</button>
         </div>
-        <div class="books-grid">
-            <a class="book-item" asp-page="/BookDetails">
-                <div class="book-cover">
-                    <img src="https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=300&h=450&fit=crop&crop=center" alt="The Crimson Tide" />
-                </div>
-                <h3 class="book-title">The Crimson Tide</h3>
-            </a>
-            <a class="book-item" asp-page="/BookDetails">
-                <div class="book-cover">
-                    <img src="https://images.unsplash.com/photo-1481627834876-b7833e8f5570?w=300&h=450&fit=crop&crop=center" alt="The Iron Crown" />
-                </div>
-                <h3 class="book-title">The Iron Crown</h3>
-            </a>
-            <a class="book-item" asp-page="/BookDetails">
-                <div class="book-cover">
-                    <img src="https://images.unsplash.com/photo-1518373714866-3f1478910cc0?w=300&h=450&fit=crop&crop=center" alt="The Serpent's Kiss" />
-                </div>
-                <h3 class="book-title">The Serpent's Kiss</h3>
-            </a>
-            <a class="book-item" asp-page="/BookDetails">
-                <div class="book-cover">
-                    <img src="https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=300&h=450&fit=crop&crop=center" alt="The Obsidian Mirror" />
-                </div>
-                <h3 class="book-title">The Obsidian Mirror</h3>
-            </a>
-            <a class="book-item" asp-page="/BookDetails">
-                <div class="book-cover">
-                    <img src="https://images.unsplash.com/photo-1544947950-fa07a98d237f?w=300&h=450&fit=crop&crop=center" alt="The Phoenix Rises" />
-                </div>
-                <h3 class="book-title">The Phoenix Rises</h3>
-            </a>
-        </div>
+        @if (Model.PlanToRead.Any())
+        {
+            <div class="books-grid">
+                @foreach (var book in Model.PlanToRead)
+                {
+                    <partial name="Shared/_BookShelfItem" model="book" />
+                }
+            </div>
+        }
+        else
+        {
+            <div class="section-empty-message">
+                <h3>Your queue is clear</h3>
+                <p>Keep your reading list growing by adding books you want to explore.</p>
+            </div>
+        }
     </section>
 </main>

--- a/BookWise.Web/Pages/Shared/_BookShelfItem.cshtml
+++ b/BookWise.Web/Pages/Shared/_BookShelfItem.cshtml
@@ -1,0 +1,29 @@
+@model BookWise.Web.Models.Book
+@{
+    var coverUrl = string.IsNullOrWhiteSpace(Model.CoverImageUrl)
+        ? Url.Content("~/img/book-placeholder.svg")
+        : Model.CoverImageUrl!;
+    var statusKey = Model.Status?.ToLowerInvariant();
+    var statusLabel = statusKey switch
+    {
+        "reading" => "In progress",
+        "read" => "Completed",
+        "plan-to-read" => "On deck",
+        _ => Model.Status ?? string.Empty
+    };
+}
+
+<a class="book-item" asp-page="/BookDetails" asp-route-id="@Model.Id">
+    <div class="book-cover">
+        <img src="@coverUrl" alt="@Model.Title cover" loading="lazy" />
+    </div>
+    <h3 class="book-title">@Model.Title</h3>
+    @if (!string.IsNullOrWhiteSpace(Model.Author))
+    {
+        <p class="book-author">@Model.Author</p>
+    }
+    @if (!string.IsNullOrWhiteSpace(statusLabel))
+    {
+        <span class="book-status" data-status="@statusKey">@statusLabel</span>
+    }
+</a>

--- a/BookWise.Web/wwwroot/css/site.css
+++ b/BookWise.Web/wwwroot/css/site.css
@@ -779,6 +779,57 @@ a:hover {
   -webkit-box-orient: vertical;
 }
 
+.book-author {
+  margin: 0.35rem 0 0;
+  font-size: 0.8rem;
+  color: var(--gray-500);
+}
+
+.book-status {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-top: 0.6rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  background: rgba(30, 167, 253, 0.12);
+  color: var(--brand-600);
+}
+
+.book-status[data-status="read"] {
+  background: rgba(34, 197, 94, 0.15);
+  color: #15803d;
+}
+
+.book-status[data-status="plan-to-read"] {
+  background: rgba(234, 179, 8, 0.15);
+  color: #b45309;
+}
+
+.section-empty-message {
+  text-align: center;
+  padding: 2.25rem 1.75rem;
+  border-radius: 14px;
+  background: var(--surface);
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  color: var(--gray-500);
+}
+
+.section-empty-message h3 {
+  margin: 0 0 0.75rem;
+  font-size: 1.05rem;
+  color: var(--gray-700);
+}
+
+.section-empty-message p {
+  margin: 0;
+  line-height: 1.5;
+}
+
 /* Responsive Design */
 @media (max-width: 768px) {
   .header-content {

--- a/BookWise.Web/wwwroot/img/book-placeholder.svg
+++ b/BookWise.Web/wwwroot/img/book-placeholder.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="300" height="450" viewBox="0 0 300 450" role="img" aria-labelledby="title desc">
+  <title id="title">Book cover placeholder</title>
+  <desc id="desc">A stylized book cover placeholder with subtle gradients</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#dbeafe" />
+      <stop offset="100%" stop-color="#eff6ff" />
+    </linearGradient>
+    <linearGradient id="stripe" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#3b82f6" stop-opacity="0.35" />
+      <stop offset="100%" stop-color="#1d4ed8" stop-opacity="0.65" />
+    </linearGradient>
+  </defs>
+  <rect width="300" height="450" fill="url(#bg)" rx="16" ry="16" />
+  <rect x="48" y="72" width="36" height="306" fill="url(#stripe)" rx="8" ry="8" />
+  <rect x="108" y="112" width="132" height="12" fill="#60a5fa" opacity="0.65" />
+  <rect x="108" y="148" width="132" height="12" fill="#60a5fa" opacity="0.45" />
+  <rect x="108" y="184" width="96" height="12" fill="#60a5fa" opacity="0.3" />
+  <rect x="108" y="308" width="96" height="12" fill="#1d4ed8" opacity="0.4" />
+</svg>


### PR DESCRIPTION
## Summary
- render each bookshelf section from the page model instead of hard-coded anchors and show empty states when there are no books
- extract a reusable `_BookShelfItem` partial that preserves the existing card markup while adding author and status details with a placeholder cover
- extend site styling to support the shared book metadata, empty-state messaging, and placeholder artwork

## Testing
- dotnet build *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dfd63dff84832cbf55920ec9de8871